### PR TITLE
FIX: typo at 27 (paernt > parent)

### DIFF
--- a/src/file_item_list/directory_item.rs
+++ b/src/file_item_list/directory_item.rs
@@ -24,7 +24,7 @@ impl Directory {
 
             #[cfg(not(target_os = "windows"))]
             {
-                paernt = PathBuf::from(r"/")
+                parent = PathBuf::from(r"/")
             }
         }
         Self { name, path, parent }


### PR DESCRIPTION
It was unable to compile due to this typographical error. now it does

the error in question:
...
   Compiling serde_derive v1.0.219
   Compiling ron v0.7.1
   Compiling simple-tui-file-manager v0.1.1 (/home/ludwig/GithubRepo/simple-tui-file-manager)
error[E0425]: cannot find value `paernt` in this scope
  --> src/file_item_list/directory_item.rs:27:17
   |
27 |                 paernt = PathBuf::from(r"/")
   |                 ^^^^^^
   |
help: a local variable with a similar name exists
   |
27 -                 paernt = PathBuf::from(r"/")
27 +                 parent = PathBuf::from(r"/")
   |

For more information about this error, try `rustc --explain E0425`.
warning: `simple-tui-file-manager` (bin "simple-tui-file-manager") generated 5 warnings
error: could not compile `simple-tui-file-manager` (bin "simple-tui-file-manager") due to 1 previous error; 5 warnings emitted